### PR TITLE
Add search by cadastral parcel

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -340,7 +340,42 @@
     }, {
         "name": "Search",
         "cfg": {
-          "searchOptions": {"services": [
+          "searchOptions": {"services": [{
+              "priority": 2,
+              "type": "bzComuniCatastali",
+              "displayName": "${properties.title}",
+              "subTitle": "${properties.description}",
+              "geomService" : {
+                "type": "wfs",
+                "options": {
+                  "url": "/geoserver/wfs",
+                  "typeName": "Ambiente:comuni_catast",
+                  "srsName": "EPSG:4326",
+                  "staticFilter": "CCAT_CODIC = ${properties.code}"
+                }
+              },
+              "nestedPlaceholderMsgId": "search.partNestedPlaceholder",
+              "then" : [{
+                  "type": "bzParticella",
+                  "displayName": "${properties.codice}",
+                  "searchTextTemplate": "${properties.codice}",
+                  "subTitle": "${properties.descTipo}",
+                  "geomService" : {
+                    "type": "wfs",
+                    "options": {
+                      "url": "/geoserver/wfs",
+                      "typeName": "Cartografia:particelle",
+                      "srsName": "EPSG:4326",
+                      "staticFilter": "NUM = '${properties.codice}' AND COM = ${properties.comcat}"
+                    }
+                  },
+                  "options": {
+                    "protocol": "http",
+                    "host": "sit.comune.bolzano.it",
+                    "pathname": "/GeoInfo/ParticelleServlet"
+                  }
+                }]
+            },
              {
               "type": "bzVie",
               "displayName": "${properties.desc}",
@@ -541,7 +576,42 @@
       {
           "name": "Search",
           "cfg": {
-            "searchOptions": {"services": [
+            "searchOptions": {"services": [{
+              "priority": 2,
+              "type": "bzComuniCatastali",
+              "displayName": "${properties.title}",
+              "subTitle": "${properties.description}",
+              "geomService" : {
+                "type": "wfs",
+                "options": {
+                  "url": "/geoserver/wfs",
+                  "typeName": "Ambiente:comuni_catast",
+                  "srsName": "EPSG:4326",
+                  "staticFilter": "CCAT_CODIC = ${properties.code}"
+                }
+              },
+              "nestedPlaceholderMsgId": "search.partNestedPlaceholder",
+              "then" : [{
+                  "type": "bzParticella",
+                  "displayName": "${properties.codice}",
+                  "searchTextTemplate": "${properties.codice}",
+                  "subTitle": "${properties.descTipo}",
+                  "geomService" : {
+                    "type": "wfs",
+                    "options": {
+                      "url": "/geoserver/wfs",
+                      "typeName": "Cartografia:particelle",
+                      "srsName": "EPSG:4326",
+                      "staticFilter": "NUM = '${properties.codice}' AND COM = ${properties.comcat}"
+                    }
+                  },
+                  "options": {
+                    "protocol": "http",
+                    "host": "sit.comune.bolzano.it",
+                    "pathname": "/GeoInfo/ParticelleServlet"
+                  }
+                }]
+            },
                {
                 "type": "bzVie",
                 "displayName": "${properties.desc}",

--- a/translations/data.de-DE
+++ b/translations/data.de-DE
@@ -13,6 +13,7 @@
             "loadingerror": "Diese Ebene wurde nicht korrekt geladen"
         },
         "search":{
+            "partNestedPlaceholder": "Parzelle einfügen...",
             "nestedPlaceholder": "Bitte, legen Sie auf Bürgernummer"
         },
         "queryform": {

--- a/translations/data.it-IT
+++ b/translations/data.it-IT
@@ -13,6 +13,7 @@
       "loadingerror": "Il livello non è stato caricato correttamente"
     },
     "search": {
+      "partNestedPlaceholder": "Inserisci codice particella...",
       "nestedPlaceholder": "Inserisci un civico"
     },
     "queryform": {


### PR DESCRIPTION
The user can search cadastral parcel directly from the search bar. 
- start writing in search bar something like: 
  - "Particella Fondiaria" or "Edificabile"
  - "Bauparzelle" or "Grundparzelle"
  - "Bolzano" or "Bozen"
  - "Gries"
  - "Dodiciville" or "Zwölfmalgreien"
You will be able to choose between some options, grayed out (if the text you are searching match also some street, you will see also the streets that match): 
![image](https://user-images.githubusercontent.com/1279510/31673567-da53fb52-b35f-11e7-8e49-4e8f0cc4f5cc.png)
Selecting one of them you will zoom to the selected zone. Then you can write (part of) the code of the cadastral parcel to search. 
![image](https://user-images.githubusercontent.com/1279510/31673663-155bbdfc-b360-11e7-9f42-46236d0ae318.png)
And select one entry to zoom and highlight the parcel.
![image](https://user-images.githubusercontent.com/1279510/31673705-396ada0c-b360-11e7-86ff-3ed0601ea2d9.png)
