### PR TITLE
Fix #54 Plugin ricerca particelle edilizie

### DIFF
--- a/assets/themes/default/theme.less
+++ b/assets/themes/default/theme.less
@@ -14,3 +14,29 @@
         border-color:  @ms2-color-primary;
     }
 }
+
+.ms-parcel-search {
+    display: flex;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    top: 0;
+    left: 0;
+    z-index: 5000;
+
+    > div {
+        margin: auto;
+        h4 {
+            color: @ms2-color-text-primary;
+        }
+
+        .ms-parcel-loader {
+            > div {
+                border-color: fade(@ms2-color-text-primary, 20%);
+                border-left-color: @ms2-color-text-primary;
+            }
+            
+        }
+    }
+}

--- a/js/actions/__tests__/searchparcel-test.js
+++ b/js/actions/__tests__/searchparcel-test.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+
+const {
+    SET_OPTIONS,
+    LOADING_PARCEL,
+    COMPLETE_SEARCH,
+    setOptions,
+    loadingParcel,
+    completeSearch
+} = require('../searchparcel');
+
+describe('Test correctness of the searchparcel actions', () => {
+
+    it('setOptions', () => {
+        const result = setOptions({service: {}});
+        expect(result.type).toEqual(SET_OPTIONS);
+        expect(result.options).toEqual({service: {}});
+    });
+
+    it('loadingParcel', () => {
+        const result = loadingParcel(true);
+        expect(result.type).toEqual(LOADING_PARCEL);
+        expect(result.loading).toEqual(true);
+    });
+
+    it('completeSearch', () => {
+        const result = completeSearch();
+        expect(result.type).toEqual(COMPLETE_SEARCH);
+    });
+});

--- a/js/actions/searchparcel.js
+++ b/js/actions/searchparcel.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const SET_OPTIONS = 'SEARCH_PARCEL:SET_OPTIONS';
+const LOADING_PARCEL = 'SEARCH_PARCEL:LOADING_PARCEL';
+const COMPLETE_SEARCH = 'SEARCH_PARCEL:COMPLETE_SEARCH';
+
+function setOptions(options) {
+    return {
+        type: SET_OPTIONS,
+        options
+    };
+}
+
+function loadingParcel(loading) {
+    return {
+        type: LOADING_PARCEL,
+        loading
+    };
+}
+
+function completeSearch() {
+    return {
+        type: COMPLETE_SEARCH
+    };
+}
+
+module.exports = {
+    SET_OPTIONS,
+    LOADING_PARCEL,
+    COMPLETE_SEARCH,
+    setOptions,
+    loadingParcel,
+    completeSearch
+};

--- a/js/epics/__tests__/searchparcel-test.js
+++ b/js/epics/__tests__/searchparcel-test.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+
+const {searchParcelEpic} = require('../searchparcel');
+const {testEpic} = require('../../../MapStore2/web/client/epics/__tests__/epicTestUtils');
+const {COMPLETE_SEARCH, LOADING_PARCEL} = require('../../actions/searchparcel');
+const {configureMap} = require('../../../MapStore2/web/client/actions/config');
+const {TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_RESET, TEXT_SEARCH_TEXT_CHANGE} = require('../../../MapStore2/web/client/actions/search');
+const {SHOW_NOTIFICATION} = require('../../../MapStore2/web/client/actions/notifications');
+
+const map = {
+    present: {
+        size: {width: 1387, height: 946},
+        projection: "EPSG:900913"
+    }
+};
+
+const searchparcel = {
+    service: {
+        priority: 2,
+        type: "bzComuniCatastali",
+        displayName: "${properties.title}",
+        subTitle: "${properties.description}",
+        geomService: {
+            type: "wfs",
+            options: {
+                url: "http://geoserv02:8080/geoserver/wfs",
+                typeName: "Ambiente:comuni_catast",
+                srsName: "EPSG:4326",
+                staticFilter: "CCAT_CODIC = ${properties.code}"
+            }
+        },
+        then: [
+            {
+                type: "bzParticella",
+                displayName: "${properties.codice}",
+                searchTextTemplate: "${properties.codice}",
+                subTitle: "${properties.descTipo}",
+                geomService: {
+                    type: "wfs",
+                    options: {
+                        url: "http://sit.comune.bolzano.it/geoserver/wfs",
+                        typeName: "Cartografia:particelle",
+                        srsName: "EPSG:4326",
+                        staticFilter: "NUM = '${properties.codice}' AND COM = ${properties.comcat}"
+                    }
+                },
+                options: {
+                    protocol: "http",
+                    host: "sit.comune.bolzano.it",
+                    pathname: "/GeoInfo/ParticelleServlet"
+                }
+            }
+        ]
+    },
+    resultStyle: {
+        iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
+        shadowUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png",
+        iconSize: [25, 41],
+        iconAnchor: [12, 41],
+        popupAnchor: [1, -34],
+        shadowSize: [41, 41],
+        color: "#3388ff",
+        weight: 4,
+        dashArray: "",
+        fillColor: "#3388ff",
+        fillOpacity: 0.2
+    },
+    searchKeys: {
+        comcat: 'comCat',
+        codice: 'particella',
+        type: 'tipoPart'
+    }
+};
+
+describe('searchparcel epics', () => {
+
+    it('tests searchParcelEpic no state', (done) => {
+        const epicResult = actions => {
+            try {
+                expect(actions.length).toBe(1);
+                actions.map((action) => {
+                    expect(action.type).toBe(COMPLETE_SEARCH);
+                });
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+        const state = {};
+        testEpic(searchParcelEpic, 1, [{type: '@@router/LOCATION_CHANGE'}, configureMap()], epicResult, state);
+    });
+
+    it('tests searchParcelEpic with service and no query', (done) => {
+        const epicResult = actions => {
+            try {
+                expect(actions.length).toBe(5);
+                expect(actions[0].type).toBe(LOADING_PARCEL);
+                expect(actions[0].loading).toBe(false);
+                expect(actions[1].type).toBe(TEXT_SEARCH_RESULTS_PURGE);
+                expect(actions[2].type).toBe(TEXT_SEARCH_RESET);
+                expect(actions[3].type).toBe(LOADING_PARCEL);
+                expect(actions[3].loading).toBe(false);
+                expect(actions[4].type).toBe(COMPLETE_SEARCH);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+        const state = {
+            searchparcel
+        };
+        testEpic(searchParcelEpic, 5, [{type: '@@router/LOCATION_CHANGE'}, configureMap()], epicResult, state);
+    });
+
+    it('tests searchParcelEpic with service and query with error', (done) => {
+        const epicResult = actions => {
+            try {
+                expect(actions.length).toBe(8);
+                expect(actions[0].type).toBe(LOADING_PARCEL);
+                expect(actions[0].loading).toBe(false);
+                expect(actions[1].type).toBe(LOADING_PARCEL);
+                expect(actions[1].loading).toBe(true);
+                expect(actions[2].type).toBe(TEXT_SEARCH_TEXT_CHANGE);
+                expect(actions[3].type).toBe(LOADING_PARCEL);
+                expect(actions[3].loading).toBe(false);
+                expect(actions[4].type).toBe(TEXT_SEARCH_RESULTS_PURGE);
+                expect(actions[5].type).toBe(TEXT_SEARCH_RESET);
+                expect(actions[6].type).toBe(SHOW_NOTIFICATION);
+                expect(actions[7].type).toBe(COMPLETE_SEARCH);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+        const state = {
+            searchparcel,
+            map
+        };
+        testEpic(searchParcelEpic, 8, [{type: '@@router/LOCATION_CHANGE', payload: {search: '?particella=.442&comCat=669&tipoPart=partedif'}}, configureMap()], epicResult, state);
+    });
+
+});

--- a/js/epics/searchparcel.js
+++ b/js/epics/searchparcel.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+const Rx = require('rxjs');
+const {MAP_CONFIG_LOADED} = require('../../MapStore2/web/client/actions/config');
+const {LOCATION_CHANGE} = require('react-router-redux');
+const {API} = require('../../MapStore2/web/client/api/searchText');
+const url = require('url');
+const {selectNestedService, selectSearchItem, resultsPurge, resetSearch, searchTextChanged} = require('../../MapStore2/web/client/actions/search');
+const {mapSelector} = require('../../MapStore2/web/client/selectors/map');
+const {head, trim} = require('lodash');
+const {optionsSelector} = require('../selectors/searchparcel');
+const {warning, error} = require('../../MapStore2/web/client/actions/notifications');
+const {loadingParcel, COMPLETE_SEARCH, completeSearch} = require('../actions/searchparcel');
+
+const loadedParcelResults = (state, {results, codice, nestedService, comcatObj, style, mapConfig}) => {
+    const item = results && head((results || [])
+        .filter(result => result.properties && result.properties.codice && result.properties.codice + '' === codice + '')
+        .map(result => ({...result, __SERVICE__: nestedService}))
+    );
+    return item && mapConfig ?
+        Rx.Observable.concat(
+            Rx.Observable.of(
+                selectNestedService(
+                    [nestedService],
+                    {
+                        text: comcatObj && comcatObj.properties && comcatObj.properties.title,
+                        placeholder: '',
+                        placeholderMsgId: ''
+                    },
+                    ''
+                ),
+                selectSearchItem(item, mapConfig, style),
+                loadingParcel(false),
+                resultsPurge(),
+                completeSearch()
+            )
+        )
+        : Rx.Observable.of(
+            loadingParcel(false),
+            resultsPurge(),
+            resetSearch(),
+            warning({
+                title: 'searchparcel.warningTitle',
+                message: 'searchparcel.warningMessage',
+                autoDismiss: 6,
+                position: 'tc'
+            }),
+            completeSearch()
+        );
+};
+
+
+const searchParcelEpic = (action$, store) =>
+    action$.ofType(LOCATION_CHANGE)
+        .switchMap((locale) =>
+            action$.ofType(MAP_CONFIG_LOADED)
+                .switchMap(() => {
+                    const state = store.getState();
+                    const {service, style, searchKeys} = optionsSelector(store.getState());
+                    return service && service.type ? Rx.Observable.fromPromise(API.Utils.getService(service.type)(''))
+                        .switchMap(comuniCatastali => {
+                            const mapConfig = mapSelector(state);
+
+                            const search = locale && locale.payload && locale.payload.search || '';
+                            const query = url.parse(search, true).query;
+
+                            const comcat = searchKeys && searchKeys.comcat && query[searchKeys.comcat] || query && query.comcat;
+                            const codice = searchKeys && searchKeys.codice && query[searchKeys.codice] || query && query.codice;
+                            const type = searchKeys && searchKeys.type && query[searchKeys.type] || query && query.type;
+                            const comcatObj = head(comuniCatastali.filter(comune => comune && comune.properties && comune.properties.code
+                                && trim(comune.properties.code + '') === trim(comcat + '') && trim(comune.properties.tipo + '') === trim(type + '')));
+
+                            const nestedService = head((service && service.then || []).map((nestedServ) => ({
+                                ...nestedServ,
+                                options: {
+                                    item: comcatObj,
+                                    ...nestedServ.options
+                                }
+                            })));
+
+                            return !comcatObj || !codice || !type || !nestedService || !mapConfig ?
+                                Rx.Observable.of(resultsPurge(), resetSearch(), loadingParcel(false), completeSearch())
+                                : Rx.Observable.concat(
+                                    Rx.Observable.of(
+                                        loadingParcel(true),
+                                        searchTextChanged(' ')
+                                    ),
+                                    Rx.Observable.fromPromise(API.Utils.getService(nestedService.type)(codice, {...nestedService.options}))
+                                        .switchMap((results) => loadedParcelResults(state, {results, codice, nestedService, comcatObj, style, mapConfig}))
+                                        .catch(() => {
+                                            return Rx.Observable.of(
+                                                loadingParcel(false),
+                                                resultsPurge(),
+                                                resetSearch(),
+                                                error({
+                                                    title: 'searchparcel.errorTitle',
+                                                    message: 'searchparcel.errorMessage',
+                                                    autoDismiss: 6,
+                                                    position: 'tc'
+                                                }),
+                                                completeSearch()
+                                            );
+                                        })
+                            );
+                        })
+                        .startWith(loadingParcel(false))
+                        .takeUntil(action$.ofType(COMPLETE_SEARCH))
+                        :
+                        Rx.Observable.of(completeSearch());
+                })
+                .takeUntil(action$.ofType(COMPLETE_SEARCH))
+        );
+
+module.exports = {
+    searchParcelEpic
+};

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -80,7 +80,8 @@ module.exports = {
         WidgetsPlugin: require('../MapStore2/web/client/plugins/Widgets'),
         WidgetsBuilderPlugin: require('../MapStore2/web/client/plugins/WidgetsBuilder'),
         // DetailsPlugin: require('../MapStore2/web/client/plugins/Details'),
-        TOCItemsSettingsPlugin: require('../MapStore2/web/client/plugins/TOCItemsSettings')
+        TOCItemsSettingsPlugin: require('../MapStore2/web/client/plugins/TOCItemsSettings'),
+        SearchParcel: require('./plugins/SearchParcel')
         },
     requires: {
         ReactSwipe: require('react-swipeable-views').default,

--- a/js/plugins/SearchParcel.jsx
+++ b/js/plugins/SearchParcel.jsx
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const PropTypes = require('prop-types');
+const {connect} = require('react-redux');
+const {createSelector} = require('reselect');
+const Loader = require('../../MapStore2/web/client/components/misc/Loader');
+const Message = require('../../MapStore2/web/client/components/I18N/Message');
+
+/**
+ * SearchParcel Plugin.
+ * Add particella, comCat and tipoPart paramiters to url to search a specific parcel.
+ * All paramiters must be declared in url.
+ * Application will not perform searches in case of missing query param or services.
+ *
+ * example for partedif
+ * /#/viewer/openlayers/:mapid
+ *  ?particella=.442
+ *  &comCat=669
+ *  &tipoPart=partedif
+ *
+ * example for partfond
+ * /#/viewer/openlayers/:mapid
+ *  ?particella=442
+ *  &comCat=669
+ *  &tipoPart=partfond
+ *
+ * @memberof plugins.SearchParcel
+ * @name SearchParcel
+ * @class
+ * @prop {object} service service to request parcel data and geometries (similar to search configuration)
+ * @prop {object} resultStyle style to apply to result geometries
+ * @prop {object} searchKeys object to map query paramiters
+ */
+
+class SearchParcel extends React.Component {
+
+    static propTypes = {
+        service: PropTypes.object,
+        resultStyle: PropTypes.object,
+        searchKeys: PropTypes.object,
+        setOptions: PropTypes.func,
+        loading: PropTypes.bool
+    };
+
+    static defaultProps = {
+        service: {
+            priority: 2,
+            type: "bzComuniCatastali",
+            displayName: "${properties.title}",
+            subTitle: "${properties.description}",
+            geomService: {
+                type: "wfs",
+                options: {
+                    url: "http://geoserv02:8080/geoserver/wfs",
+                    typeName: "Ambiente:comuni_catast",
+                    srsName: "EPSG:4326",
+                    staticFilter: "CCAT_CODIC = ${properties.code}"
+                }
+            },
+            then: [
+                {
+                    type: "bzParticella",
+                    displayName: "${properties.codice}",
+                    searchTextTemplate: "${properties.codice}",
+                    subTitle: "${properties.descTipo}",
+                    geomService: {
+                        type: "wfs",
+                        options: {
+                            url: "http://sit.comune.bolzano.it/geoserver/wfs",
+                            typeName: "Cartografia:particelle",
+                            srsName: "EPSG:4326",
+                            staticFilter: "NUM = '${properties.codice}' AND COM = ${properties.comcat}"
+                        }
+                    },
+                    options: {
+                        protocol: "http",
+                        host: "sit.comune.bolzano.it",
+                        pathname: "/GeoInfo/ParticelleServlet"
+                    }
+                }
+            ]
+        },
+        resultStyle: {
+            iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
+            shadowUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png",
+            iconSize: [25, 41],
+            iconAnchor: [12, 41],
+            popupAnchor: [1, -34],
+            shadowSize: [41, 41],
+            color: "#3388ff",
+            weight: 4,
+            dashArray: "",
+            fillColor: "#3388ff",
+            fillOpacity: 0.2
+        },
+        searchKeys: {
+            comcat: 'comCat',
+            codice: 'particella',
+            type: 'tipoPart'
+        },
+        setOptions: () => {}
+    };
+
+    componentWillMount() {
+        this.props.setOptions({
+            service: this.props.service,
+            style: this.props.resultStyle,
+            searchKeys: this.props.searchKeys
+        });
+    }
+
+    render() {
+        return this.props.loading ? (
+        <div className="ms-parcel-search">
+            <div>
+                <Loader size={176} className="ms-parcel-loader"/>
+                <h4 className="text-center"><Message msgId="searchparcel.loading" /></h4>
+            </div>
+        </div>) : null;
+    }
+}
+
+const {setOptions} = require('../actions/searchparcel');
+const {loadingSelector} = require('../selectors/searchparcel');
+const searchEpic = require('../../MapStore2/web/client/epics/search');
+const searchParcelEpic = require('../epics/searchparcel');
+
+const searchParcelSelector = createSelector([
+    loadingSelector
+], (loading) => ({
+    loading
+}));
+
+const SearchParcelPlugin = connect(searchParcelSelector, {
+    setOptions: setOptions
+})(SearchParcel);
+
+module.exports = {
+    SearchParcelPlugin,
+    reducers: {
+        searchparcel: require('../reducers/searchparcel'),
+        search: require('../../MapStore2/web/client/reducers/search'),
+        mapInfo: require('../../MapStore2/web/client/reducers/mapInfo')
+    },
+    epics: {...searchEpic, ...searchParcelEpic}
+};

--- a/js/reducers/__tests__/searchparcel-test.js
+++ b/js/reducers/__tests__/searchparcel-test.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+
+const searchparcel = require('../searchparcel');
+const {setOptions, loadingParcel} = require('../../actions/searchparcel');
+
+describe('Test the searchparcel reducer', () => {
+
+    it('setOptions', () => {
+        const state = searchparcel(undefined, setOptions({service: 'service'}));
+        expect(state.service).toBe('service');
+    });
+
+    it('loadingParcel', () => {
+        const state = searchparcel(undefined, loadingParcel(true));
+        expect(state.loading).toBe(true);
+    });
+});

--- a/js/reducers/searchparcel.js
+++ b/js/reducers/searchparcel.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+const {SET_OPTIONS, LOADING_PARCEL} = require('../actions/searchparcel');
+
+function searchparcel(state = {}, action) {
+    switch (action.type) {
+        case SET_OPTIONS: {
+            return {...state, ...action.options};
+        }
+        case LOADING_PARCEL: {
+            return {...state, loading: action.loading};
+        }
+        default:
+            return state;
+    }
+}
+
+module.exports = searchparcel;

--- a/js/selectors/__tests__/searchparcel-test.js
+++ b/js/selectors/__tests__/searchparcel-test.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+
+const {
+    optionsSelector,
+    loadingSelector
+} = require('../searchparcel');
+
+describe('Test correctness of the searchparcel selectors', () => {
+
+    it('optionsSelector', () => {
+        expect(optionsSelector({})).toEqual({});
+        expect(optionsSelector({searchparcel: { options: {} }})).toEqual({ options: {} });
+    });
+
+    it('loadingSelector', () => {
+        expect(loadingSelector({})).toEqual(false);
+        expect(loadingSelector({searchparcel: {loading: true}})).toEqual(true);
+    });
+
+});

--- a/js/selectors/searchparcel.js
+++ b/js/selectors/searchparcel.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {get} = require('lodash');
+
+module.exports = {
+    optionsSelector: state => state && get(state, 'searchparcel') || {},
+    loadingSelector: state => state && get(state, 'searchparcel.loading') ? true : false
+};

--- a/localConfig.json
+++ b/localConfig.json
@@ -541,7 +541,8 @@
         "declineUrl" : "http://www.google.com"
         }
     },
-    "OmniBar", "Login", "Save", "SaveAs", "BurgerMenu", "Expander", "Undo", "Redo", "Notifications", "WidgetsBuilder", "Widgets"
+    "OmniBar", "Login", "Save", "SaveAs", "BurgerMenu", "Expander", "Undo", "Redo", "Notifications", "WidgetsBuilder", "Widgets",
+    "SearchParcel"
   ],
     "embedded": [
       {

--- a/translations/data.de-DE
+++ b/translations/data.de-DE
@@ -23,6 +23,13 @@
             "spatialfilter": {
                 "selection_method": "Auswahl Methode"
             }
+        },
+        "searchparcel": {
+            "warningTitle": "Fehlendes Grundparzelle",
+            "warningMessage": "Das angeforderte Grundparzelle konnte nicht gefunden werden",
+            "loading": "Grundparzelle wird geladen",
+            "errorTitle": "Servizio nicht verfügbar",
+            "errorMessage": "Der Suchdienst ist nicht erreichbar"
         }
     }
 }

--- a/translations/data.it-IT
+++ b/translations/data.it-IT
@@ -23,6 +23,13 @@
       "spatialfilter": {
         "selection_method": "Metodo di selezione"
       }
+    },
+    "searchparcel": {
+      "warningTitle": "Particella mancante",
+      "warningMessage": "Non è stato possibile trovare la particella richiesta",
+      "loading": "Caricamento Particella",
+      "errorTitle": "Servizio non disponibile",
+      "errorMessage": "Il servizio di ricerca non è raggiungibile"
     }
   }
 }


### PR DESCRIPTION
Added plugin to perform query to particelle service from url.
Needed params `particella`, `comCat` and `tipoPart`.

example for partedif
`/#/viewer/openlayers/:mapid?particella=.442&comCat=669&tipoPart=partedif`

 example for partfond
`/#/viewer/openlayers/:mapid?particella=442&comCat=669&tipoPart=partfond`


results style can be configurated as follow:
```
{
 "name": "SearchParcel",
 "cfg": {
  "resultStyle": {
    "iconUrl": "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
    "shadowUrl": "https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png",
    "iconSize": [25, 41],
    "iconAnchor": [12, 41],
    "popupAnchor": [1, -34],
    "shadowSize": [41, 41],
    "color": "#3388ff",
    "weight": 4,
    "dashArray": "",
    "fillColor": "#3388ff",
    "fillOpacity": 0.2
  }
 }
}
```

params can be mapped to new vaules with searchKeys configuration object as follow:

```
{
 "name": "SearchParcel",
 "cfg": {
   "searchKeys": {
   "comcat": "myComcatKey",
   "codice": "myParticellaKey",
   "type": "myTipoPartKey"
  }
 }
}
```
now the query in url is `?myParticellaKey=442&myComcatKey=669&myTipoPartKey=partfond`

connected to https://github.com/geosolutions-it/MapStore2/issues/3042