### PR TITLE
Fixed issue when switch from roadAccidents to normal map

### DIFF
--- a/js/epics/__tests__/accidents-test.js
+++ b/js/epics/__tests__/accidents-test.js
@@ -2,7 +2,7 @@ const expect = require('expect');
 const { testEpic } = require('../../../MapStore2/web/client/epics/__tests__/epicTestUtils');
 
 const {MAP_CONFIG_LOADED} = require('../../../MapStore2/web/client/actions/config');
-const { SET_CONTROL_PROPERTY } = require('../../../MapStore2/web/client/actions/controls');
+const { SET_CONTROL_PROPERTY, RESET_CONTROLS } = require('../../../MapStore2/web/client/actions/controls');
 
 const {RESET, applyChanges} = require('../../actions/accidents');
 const { CHANGE_LAYER_PARAMS } = require('../../../MapStore2/web/client/actions/layers');
@@ -15,7 +15,37 @@ describe('accidents epic', () => {
             expect(actions.length).toBe(3);
             expect(actions[0].type).toBe(RESET);
             expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[1]. control).toBe("drawer");
+            expect(actions[1]. property).toBe("enabled");
+            expect(actions[1]. value).toBe(true);
             expect(actions[2].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[2]. control).toBe("drawer");
+            expect(actions[2]. property).toBe("menu");
+            expect(actions[2]. value).toBe('2');
+            done();
+
+        }, {
+            routing: { location: {
+                pathname: "/roadAccidents/openlayers/testMap"
+            }}
+        });
+    });
+    it('accidentsInitialSetup resets TOC Tab', (done) => {
+        testEpic(accidentsInitialSetup, 4, [{ type: MAP_CONFIG_LOADED }, {type: RESET_CONTROLS}], actions => {
+            expect(actions.length).toBe(4);
+            expect(actions[0].type).toBe(RESET);
+            expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[1]. control).toBe("drawer");
+            expect(actions[1]. property).toBe("enabled");
+            expect(actions[1]. value).toBe(true);
+            expect(actions[2].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[2]. control).toBe("drawer");
+            expect(actions[2]. property).toBe("menu");
+            expect(actions[2]. value).toBe('2');
+            expect(actions[3].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[3].control).toBe("drawer");
+            expect(actions[3].property).toBe("menu");
+            expect(actions[3].value).toBe('1');
             done();
 
         }, {

--- a/js/epics/accidents.js
+++ b/js/epics/accidents.js
@@ -1,10 +1,10 @@
 const Rx = require('rxjs');
 const { pathnameSelector } = require('../../MapStore2/web/client/selectors/routing');
 
-const { setControlProperty } = require('../../MapStore2/web/client/actions/controls');
+const { setControlProperty, RESET_CONTROLS } = require('../../MapStore2/web/client/actions/controls');
 
 const { APPLY_CHANGES, RESET, reset, applyChanges } = require('../actions/accidents');
-const {MAP_CONFIG_LOADED} = require('../../MapStore2/web/client/actions/config');
+const { MAP_CONFIG_LOADED } = require('../../MapStore2/web/client/actions/config');
 
 const { valuesSelector, getViewParamsLayers, getCqlLayers } = require('../selectors/accidents');
 const { changeLayerParams } = require('../../MapStore2/web/client/actions/layers');
@@ -15,7 +15,7 @@ const getDate = d => moment(d).format('YYYY-MM-DD');
  * normalize form values to make easier to create the filter
  * @return an object composed by the array of selected `days`, `types`, `fromDate` and `toDate`
  */
-const getParams = ({dow = {}, type = {}, period = {}}) => {
+const getParams = ({ dow = {}, type = {}, period = {} }) => {
     const days = Object.keys(dow).filter(d => dow[d]);
     const types = Object.keys(type).filter(t => type[t]);
     const fromDate = getDate(period.fromdate);
@@ -32,7 +32,7 @@ const getParams = ({dow = {}, type = {}, period = {}}) => {
  * Transforms form values into viewparams
  */
 const toViewParams = (values) => {
-    const {days, types, fromDate, toDate} = getParams(values);
+    const { days, types, fromDate, toDate } = getParams(values);
     const daysParam = days.length > 0 ? days.join('\\,') : "0";
     const typesParam = types.length > 0 ? types.join('\\,') : "0";
     return `dow_p:${daysParam};tpinc_p:${typesParam}` + (fromDate && toDate ? `;fromdate_p:${fromDate};todate_p:${toDate}` : '');
@@ -42,7 +42,7 @@ const toViewParams = (values) => {
  * Transforms form values into a CQL filter
  */
 const toCqlFilter = (values) => {
-    const {days, types, fromDate, toDate} = getParams(values);
+    const { days, types, fromDate, toDate } = getParams(values);
     const daysParam = days.length > 0 ? days : ["0"];
     const typesParam = types.length > 0 ? types : ["0"];
     return [
@@ -52,26 +52,26 @@ const toCqlFilter = (values) => {
     ].join(" AND ");
 };
 
-const shouldInit = ({getState = () => {}} = {}) => {
+const shouldInit = ({ getState = () => { } } = {}) => {
     const pathName = pathnameSelector(getState()) || "";
     return pathName.indexOf("roadAccidents") >= 0;
 };
 module.exports = {
-    updateRoadAccidentLayers: (action$, {getState = () => {}} = {}) =>
-        action$.ofType( APPLY_CHANGES ).switchMap( () =>
+    updateRoadAccidentLayers: (action$, { getState = () => { } } = {}) =>
+        action$.ofType(APPLY_CHANGES).switchMap(() =>
             // Send an update action for each layer to update...
             Rx.Observable.from([
                 // Layer(s) that need to update view params...
                 ...getViewParamsLayers(getState())
                     .map(l => changeLayerParams(l.id, {
                         "VIEWPARAMS": toViewParams(valuesSelector(getState()))
-                        })
+                    })
                     ),
                 // ...and layer(s) that need to update cql_filter
                 ...getCqlLayers(getState()).
                     map(l => changeLayerParams(l.id, {
-                            "CQL_FILTER": toCqlFilter(valuesSelector(getState()))
-                        })
+                        "CQL_FILTER": toCqlFilter(valuesSelector(getState()))
+                    })
                     )
             ])),
     accidentsAutoApplyOnReset: action$ => action$.ofType(RESET).switchMap(() => Rx.Observable.of(applyChanges())),
@@ -79,8 +79,11 @@ module.exports = {
         .ofType(MAP_CONFIG_LOADED)
         .filter(() => shouldInit(store))
         .switchMap(() => Rx.Observable.of(
-            reset(),
-            setControlProperty("drawer", "enabled", true),
-            setControlProperty("drawer", "menu", '2')
-        ))
+                reset(),
+                setControlProperty("drawer", "enabled", true),
+                setControlProperty("drawer", "menu", '2')
+            ).merge(
+                action$.ofType(RESET_CONTROLS).take(1).map(() => setControlProperty("drawer", "menu", '1'))
+            )
+        )
 };


### PR DESCRIPTION
When switch from roadAccidents page to another one, TOC is white, until you click on "layer" icon
![accident](https://user-images.githubusercontent.com/1279510/43763992-87e57300-9a2c-11e8-965d-cab45b80728e.gif)
