### PR TITLE
Fix #80 update Test deploy v 1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "leaflet.gridlayer.googlemutant": "0.6.4",
     "leaflet.locatecontrol": "0.62.0",
     "leaflet.nontiledlayer": "1.0.7",
-    "lodash": "4.16.6",
+    "lodash": "4.17.5",
     "lrucache": "1.0.3",
     "moment": "2.21.0",
     "node-geo-distance": "1.2.0",


### PR DESCRIPTION
I've create a new branch on MapStore2 c028_v114 where i ported the fix #80 

This PR  will align submodule of MapStore2 to [that](https://github.com/geosolutions-it/MapStore2/tree/c028_v114) branch.