### PR TITLE
86: exclude spring dependencies from print plugin

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -452,7 +452,8 @@
                 <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
                     WEB-INF/lib/commons-io-1.1.jar,
                     WEB-INF/lib/commons-logging-1.0.4.jar,
-                    WEB-INF/lib/commons-pool-1.3.jar
+                    WEB-INF/lib/commons-pool-1.3.jar,
+		            WEB-INF/lib/spring-*-3.1.0*.jar
                 </packagingExcludes>
                 <overlays>
                     <overlay>


### PR DESCRIPTION
## Description
Print plugin update caused a Spring dependencies clash between GeoStore and Print plugin. This will exclude print plugin conflicting jars form the final WAR.

 - [x] Bugfix
